### PR TITLE
fix(deps): update hono to fix high-severity IP spoofing vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",
         "axios": "^1.6.0",
-        "hono": "^4.12.0",
+        "hono": "^4.12.3",
         "qs": "^6.14.2",
         "zod": "^4.3.4"
       },
@@ -3229,9 +3229,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.3.tgz",
+      "integrity": "sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.25.1",
     "axios": "^1.6.0",
-    "hono": "^4.12.0",
+    "hono": "^4.12.3",
     "qs": "^6.14.2",
     "zod": "^4.3.4"
   },


### PR DESCRIPTION
## Overview

Updates `hono` to fix a high-severity IP spoofing vulnerability (GHSA-xh87-mx6m-69f3) that was causing the CI security audit step to fail.

## Problem

`hono@4.12.0` (which we just updated to in PR #60) has a high-severity vulnerability:
- **CVE**: Authentication Bypass by IP Spoofing in AWS Lambda ALB conninfo
- **Advisory**: https://github.com/advisories/GHSA-xh87-mx6m-69f3

This caused the CI `npm audit --omit=dev --audit-level=high` step to fail, blocking deployment.

## Fix

Updated `hono` to latest patched version.

## Verification
- ✅ `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- ✅ All 206 tests pass
- ✅ Format, lint, build all clean

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author