### PR TITLE
ci: add GitHub Packages publish to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
         run: npm test
       - name: Publish to npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish to GitHub Packages
         env:


### PR DESCRIPTION
## Overview

Two improvements to the release workflow:
1. **Add GitHub Packages publish** — package appears in the repo's Packages section
2. **Fix npm publish auth** — add explicit `NODE_AUTH_TOKEN` env var

## Changes

### 1. GitHub Packages publish (new step)

Adds a "Publish to GitHub Packages" step after the existing npm publish:
- Configures `.npmrc` for `https://npm.pkg.github.com`
- Temporarily changes package name to `@mgmonteleone/pylon-mcp-server` (GitHub Packages requires scope to match repo owner)
- Publishes with `--access public`
- Restores `package.json` afterward
- Uses `GITHUB_TOKEN` for auth (no new secrets needed)

### 2. npm publish auth fix

Adds `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env var to the existing "Publish to npm" step. While `actions/setup-node` creates the `.npmrc`, the token env var was not explicitly set, making auth fragile.

## Result

On each tagged release (`v*.*.*`), the package publishes to:
- **npmjs.org** as `@customer-support-success/pylon-mcp-server` (existing, now with explicit auth)
- **GitHub Packages** as `@mgmonteleone/pylon-mcp-server` (new)

## Verification

- ✅ YAML syntax validated
- ✅ Step ordering correct
- ✅ npm publish uses `NPM_TOKEN` org secret
- ✅ GitHub Packages uses `GITHUB_TOKEN` with `packages: write` permission