### PR TITLE
chore: bump version to 3.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.1] - 2026-02-27
+
+### Fixed
+
+- **CI Pipeline Fix**: Removed circular self-dependency from `package.json` that caused `npm ci` to fail in CI/Release workflows
+- **Node Version Alignment**: Standardized CI and Release workflows to Node 22 (LTS); previously CI used Node 20 and Release used Node 24
+- **Prettier Formatting**: Fixed formatting in `src/index.ts` and `tests/tool-descriptions.test.ts`
+
+### Added
+
+- **Pre-commit Hook**: Added `husky` + `lint-staged` to auto-format staged files with Prettier before each commit, preventing future CI format check failures
+
 ## [3.6.0] - 2026-02-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@customer-support-success/pylon-mcp-server",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@customer-support-success/pylon-mcp-server",
-      "version": "3.6.0",
+      "version": "3.6.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -5490,7 +5490,6 @@
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@customer-support-success/pylon-mcp-server",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "MCP server for Pylon API integration",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const pylonClient = createPylonClient(PYLON_API_TOKEN, PYLON_CACHE_TTL);
 // Create the McpServer instance (high-level API, replaces deprecated Server class)
 const mcpServer = new McpServer({
   name: 'pylon-mcp-server',
-  version: '3.6.0',
+  version: '3.6.1',
 });
 
 // Helper function to ensure pylonClient is initialized


### PR DESCRIPTION
Patch release to fix CI/Release workflow failures introduced in v3.6.0.

Bumps version to 3.6.1 in:
- `package.json`
- `src/index.ts`
- `CHANGELOG.md`
- `package-lock.json`

The actual fixes were merged in PR #72. This PR just bumps the version so we can tag and release.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author