### PR TITLE
fix(ci): use Node 24 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
           registry-url: 'https://registry.npmjs.org'
       - name: Install dependencies


### PR DESCRIPTION
npm publish --provenance requires npm 11 (Node 24) for OIDC-based authentication in GitHub Actions. npm 10 (Node 22) fails with ENEEDAUTH. This restores Node 24 for the release workflow while keeping Node 22 for CI.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author