### PR TITLE
chore: bump version to 3.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.6.2] - 2026-02-27
+
+### Fixed
+
+- **npm Publish**: Restored Node 24 for release workflow — `npm publish --provenance` requires npm 11 (bundled with Node 24) for OIDC-based authentication in GitHub Actions; npm 10 (Node 22) fails with `ENEEDAUTH`
+
 ## [3.6.1] - 2026-02-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@customer-support-success/pylon-mcp-server",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@customer-support-success/pylon-mcp-server",
-      "version": "3.6.1",
+      "version": "3.6.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@customer-support-success/pylon-mcp-server",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "MCP server for Pylon API integration",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const pylonClient = createPylonClient(PYLON_API_TOKEN, PYLON_CACHE_TTL);
 // Create the McpServer instance (high-level API, replaces deprecated Server class)
 const mcpServer = new McpServer({
   name: 'pylon-mcp-server',
-  version: '3.6.1',
+  version: '3.6.2',
 });
 
 // Helper function to ensure pylonClient is initialized


### PR DESCRIPTION
Patch release to fix npm publish failure in v3.6.1.

Restores Node 24 for the release workflow — `npm publish --provenance` requires npm 11 for OIDC auth.

Bumps version to 3.6.2 in `package.json`, `src/index.ts`, `CHANGELOG.md`, and `package-lock.json`.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author