### PR TITLE
chore: bump version to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Pylon MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.7.0] - 2026-02-27
 
 ### Added
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@customer-support-success/pylon-mcp-server",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@customer-support-success/pylon-mcp-server",
-      "version": "3.6.2",
+      "version": "3.7.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@customer-support-success/pylon-mcp-server",
-  "version": "3.6.2",
+  "version": "3.7.0",
   "description": "MCP server for Pylon API integration",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ const pylonClient = createPylonClient(PYLON_API_TOKEN, PYLON_CACHE_TTL);
 // Create the McpServer instance (high-level API, replaces deprecated Server class)
 const mcpServer = new McpServer({
   name: 'pylon-mcp-server',
-  version: '3.6.2',
+  version: '3.7.0',
 });
 
 // Helper function to ensure pylonClient is initialized


### PR DESCRIPTION
Minor release adding exponential backoff retry logic for transient API failures.

Bumps version to 3.7.0 in `package.json`, `src/index.ts`, `CHANGELOG.md`, and `package-lock.json`.

The feature was merged in PR #77 (implements #76). This PR just bumps the version for tagging and release.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author