### PR TITLE
chore: release v3.7.2 — CI fix & dependency updates

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to the Pylon MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.7.2] - 2026-03-31
+
+### 🔧 CI
+
+- Aligned security.yml workflow to Node 22 (was Node 20, matching CI workflow)
+
+### 📦 Dependencies
+
+- Bumped path-to-regexp from 8.3.0 to 8.4.0
+- Bumped picomatch from 2.3.1 to 2.3.2
+- Bumped flatted from 3.3.3 to 3.4.2
+- Bumped hono from 4.12.3 to 4.12.7
+- Bumped express-rate-limit from 8.2.1 to 8.3.0
+- Bumped @hono/node-server from 1.19.9 to 1.19.10
+
+### 🔒 Security
+
+- Resolved npm audit vulnerability via dependency updates
+
 ## [3.7.1] - 2026-02-27
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@customer-support-success/pylon-mcp-server",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "MCP server for Pylon API integration",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Overview

Release v3.7.2 with CI alignment and dependency updates.

### Changes

**🔧 CI**
- Aligned `security.yml` workflow to Node 22 (was Node 20, matching CI workflow)

**📦 Dependencies** (merged since v3.7.1)
- Bumped path-to-regexp 8.3.0 → 8.4.0
- Bumped picomatch 2.3.1 → 2.3.2
- Bumped flatted 3.3.3 → 3.4.2
- Bumped hono 4.12.3 → 4.12.7
- Bumped express-rate-limit 8.2.1 → 8.3.0
- Bumped @hono/node-server 1.19.9 → 1.19.10

**🔒 Security**
- Resolved npm audit vulnerability via dependency updates

**📋 Release**
- Version bumped to 3.7.2
- CHANGELOG.md updated

### Verification
- Build passes ✅
- All 221 tests pass ✅
- npm audit clean ✅

### Post-merge
Tag `v3.7.2` and push to trigger release workflow (npm + GitHub Packages publish).

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author