### PR TITLE
fix: prevent empty filter operator in search_issues_by_status

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -545,6 +545,7 @@ mcpServer.registerTool(
     inputSchema: {
       status: z
         .string()
+        .min(1, 'Status name must not be empty')
         .describe(
           'Status name (built-in state or custom, e.g., "Waiting on Eng Input"). Case-insensitive.'
         ),
@@ -552,7 +553,23 @@ mcpServer.registerTool(
     },
   },
   async ({ status, limit }) => {
-    const result = await ensurePylonClient().searchIssuesByStatus(status, { limit });
+    // Defensive guard: reject empty/whitespace-only status even if schema validation is bypassed
+    const trimmedStatus = status?.trim();
+    if (!trimmedStatus) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              error:
+                'Status name must not be empty. Provide a built-in state (e.g., "on_hold", "closed") or a custom status name (e.g., "Waiting on Eng Input").',
+            }),
+          },
+        ],
+        isError: true,
+      };
+    }
+    const result = await ensurePylonClient().searchIssuesByStatus(trimmedStatus, { limit });
     return jsonResponse({
       status_resolved: result.resolvedStatus,
       issue_count: result.issues.length,

--- a/src/pylon-client.ts
+++ b/src/pylon-client.ts
@@ -514,8 +514,17 @@ export class PylonClient {
       (error) => {
         if (error.response?.data) {
           // Extract error message from Pylon API response
+          // Pylon API returns errors in multiple formats:
+          //   { errors: ["message1", "message2"] }  — most common (e.g., search validation)
+          //   { error: "message" }                   — single error string
+          //   { message: "message" }                 — generic format
           const apiError = error.response.data;
-          const errorMessage = apiError.error || apiError.message || JSON.stringify(apiError);
+          let errorMessage: string;
+          if (Array.isArray(apiError.errors) && apiError.errors.length > 0) {
+            errorMessage = apiError.errors.join('; ');
+          } else {
+            errorMessage = apiError.error || apiError.message || JSON.stringify(apiError);
+          }
 
           // Create enhanced error with API details
           const enhancedError = new Error(
@@ -705,7 +714,23 @@ export class PylonClient {
     const body: Record<string, unknown> = {};
 
     if (options?.filter) {
-      body.filter = options.filter;
+      // Validate filter conditions: ensure no empty operators reach the API
+      const sanitizedFilter: Record<string, unknown> = {};
+      for (const [key, condition] of Object.entries(options.filter)) {
+        if (condition && typeof condition === 'object' && 'operator' in condition) {
+          if (
+            !condition.operator ||
+            (typeof condition.operator === 'string' && !condition.operator.trim())
+          ) {
+            throw new Error(
+              `Invalid filter: field "${key}" has an empty operator. ` +
+                `Each filter condition must have a valid operator (e.g., "equals", "contains", "in").`
+            );
+          }
+        }
+        sanitizedFilter[key] = condition;
+      }
+      body.filter = sanitizedFilter;
     }
     if (options?.limit) {
       body.limit = options.limit;

--- a/tests/pylon-client.core.test.ts
+++ b/tests/pylon-client.core.test.ts
@@ -242,6 +242,53 @@ describe('PylonClient - Core Functionality', () => {
       expect(result).toEqual(mockIssues);
     });
 
+    it('should throw when a filter condition has an empty operator', async () => {
+      await expect(
+        client.searchIssues({
+          filter: {
+            state: { operator: '' as any, value: 'on_hold' },
+          },
+        })
+      ).rejects.toThrow('Invalid filter: field "state" has an empty operator');
+    });
+
+    it('should throw when a filter condition has a whitespace-only operator', async () => {
+      await expect(
+        client.searchIssues({
+          filter: {
+            tags: { operator: '   ' as any, value: 'urgent' },
+          },
+        })
+      ).rejects.toThrow('Invalid filter: field "tags" has an empty operator');
+    });
+
+    it('should pass through valid filter operators without error', async () => {
+      const mockIssues = [{ id: 'issue_1', title: 'Test', status: 'open' }];
+
+      vi.spyOn(mockAxios, 'post').mockResolvedValue({
+        data: mockIssues,
+        status: 200,
+        statusText: 'OK',
+        headers: {},
+        config: {} as any,
+      });
+
+      const result = await client.searchIssues({
+        filter: {
+          state: { operator: 'equals', value: 'on_hold' },
+          tags: { operator: 'contains', value: 'urgent' },
+        },
+      });
+
+      expect(mockAxios.post).toHaveBeenCalledWith('/issues/search', {
+        filter: {
+          state: { operator: 'equals', value: 'on_hold' },
+          tags: { operator: 'contains', value: 'urgent' },
+        },
+      });
+      expect(result).toEqual(mockIssues);
+    });
+
     it('should update an issue', async () => {
       const updates = { status: 'closed', priority: 'low' } as const;
       const updated = { id: 'issue_3', title: 'Done', ...updates };

--- a/tests/pylon-client.error-handling.test.ts
+++ b/tests/pylon-client.error-handling.test.ts
@@ -110,6 +110,37 @@ describe('PylonClient - Enhanced Error Handling', () => {
       }
     });
 
+    it('should extract error messages from Pylon API "errors" array response', async () => {
+      nock(BASE_URL)
+        .post('/issues/search')
+        .reply(400, { errors: ['Invalid filter operator: '], request_id: 'req_123' });
+
+      try {
+        await client.searchIssues({
+          filter: { state: { operator: 'equals', value: 'on_hold' } },
+        });
+        expect.fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error.message).toBe('Pylon API error (400): Invalid filter operator: ');
+        expect(error.status).toBe(400);
+        expect(error.apiError.errors).toEqual(['Invalid filter operator: ']);
+      }
+    });
+
+    it('should join multiple errors from "errors" array with semicolons', async () => {
+      nock(BASE_URL)
+        .get('/issues/issue_123')
+        .reply(400, { errors: ['First error', 'Second error'] });
+
+      try {
+        await client.getIssue('issue_123');
+        expect.fail('Should have thrown an error');
+      } catch (error: any) {
+        expect(error.message).toBe('Pylon API error (400): First error; Second error');
+        expect(error.status).toBe(400);
+      }
+    });
+
     it('should prefer "error" field over "message" field', async () => {
       nock(BASE_URL)
         .get('/issues/issue_123')

--- a/tests/pylon-mcp.functional.tools.test.ts
+++ b/tests/pylon-mcp.functional.tools.test.ts
@@ -789,6 +789,24 @@ describe('pylon-mcp functional tools (stdio, mocked HTTP)', () => {
     expect(text).toContain('issue_count');
   });
 
+  it('pylon_search_issues_by_status - rejects empty status string', async () => {
+    const res = await client.callTool({
+      name: 'pylon_search_issues_by_status',
+      arguments: { status: '' },
+    });
+    const text = res?.content?.[0]?.text ?? '';
+    expect(text).toContain('must not be empty');
+  });
+
+  it('pylon_search_issues_by_status - rejects whitespace-only status string', async () => {
+    const res = await client.callTool({
+      name: 'pylon_search_issues_by_status',
+      arguments: { status: '   ' },
+    });
+    const text = res?.content?.[0]?.text ?? '';
+    expect(text).toContain('must not be empty');
+  });
+
   // pylon_update_issue with tags
   it('pylon_update_issue with tags replaces all tags', async () => {
     const res = await client.callTool({


### PR DESCRIPTION
## Problem

`pylon_search_issues_by_status` returns a 400 error from the Pylon API:

```
Pylon API error (400): {"errors":["Invalid filter operator: "],"request_id":"ee7df33a-f60c-411c-a2c5-727c5e48697c"}
```

The Pylon API received a filter condition with an empty operator string.

## Root Cause

1. **Missing input validation** — The `status` parameter used `z.string()` without `.min(1)`, allowing empty strings through. An empty status silently resolved to `on_hold` state, and could produce malformed filters.
2. **Error handler missed `errors[]` format** — The Pylon API returns errors as `{"errors": ["..."]}` (plural array), but the error interceptor only checked for `error` (singular) and `message`, falling through to raw `JSON.stringify`.
3. **No filter validation** — `searchIssues()` sent filters directly to the API without checking for empty operators.

## Fixes

- **`src/index.ts`**: Added `.min(1)` to the Zod schema for `status` and a defensive early-return guard that trims and rejects empty/whitespace-only input
- **`src/pylon-client.ts`**: 
  - Fixed error interceptor to extract messages from `errors[]` array format
  - Added filter validation in `searchIssues()` that throws a descriptive error if any condition has an empty operator

## Testing

All 221 existing tests pass.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author